### PR TITLE
add initial benchmark tests to compare Imprint/Proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+**/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "benches"]
+
 [package]
 name = "imprint"
 version = "0.1.0"

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +28,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -30,31 +54,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "apache-avro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
+dependencies = [
+ "digest",
+ "lazy_static",
+ "libflate",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "typed-builder",
+ "uuid",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -133,6 +174,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,55 +259,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "darling"
-version = "0.20.11"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.20.11"
+name = "dary_heap"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
-name = "darling_macro"
-version = "0.20.11"
+name = "digest"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
-
-[[package]]
-name = "dummy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac124e13ae9aa56acc4241f8c8207501d93afdd8d8e62f0c1f2e12f6508c65"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -265,23 +298,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "fake"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
-dependencies = [
- "deunicode",
- "dummy",
- "rand",
 ]
 
 [[package]]
@@ -297,10 +319,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "generic-array"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -337,9 +363,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -354,18 +396,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "imprint"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "proptest",
  "thiserror",
 ]
 
@@ -373,16 +408,15 @@ dependencies = [
 name = "imprint-benchmarks"
 version = "0.1.0"
 dependencies = [
+ "apache-avro",
  "bytes",
  "criterion",
- "fake",
  "imprint",
  "prost 0.12.6",
  "prost-build",
  "rand",
  "serde",
  "serde_json",
- "uuid",
 ]
 
 [[package]]
@@ -392,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -453,6 +487,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +533,25 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -564,26 +641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "lazy_static",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,7 +666,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -659,10 +716,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
+name = "quad-rand"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quote"
@@ -710,15 +767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,10 +810,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustix"
@@ -785,18 +845,6 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -843,6 +891,25 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -900,10 +967,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
+name = "typed-builder"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
@@ -917,17 +1004,14 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.3",
+ "serde",
 ]
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
+name = "version_check"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "imprint-benchmarks"
+version = "0.1.0"
+edition = "2024"
+publish = false
+build = "build.rs"
+
+[dependencies]
+imprint = { path = ".." }
+criterion = { version = "0.5", features = ["html_reports"] }
+prost = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rand = "0.8"
+bytes = "1.5"
+fake = { version = "2.9", features = ["derive"] }
+uuid = { version = "1.7", features = ["v4"] }
+
+[build-dependencies]
+prost-build = "0.13.5"
+
+[[bench]]
+name = "serialization"
+path = "src/serialization.rs"
+harness = false 

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    prost_build::compile_protos(&["proto/test_record.proto"], &["proto"])
+        .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
+}

--- a/benches/proto/test_record.proto
+++ b/benches/proto/test_record.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package test;
+
+message Product {
+    string id = 1;
+    string name = 2;
+    string description = 3;
+    double price = 4;
+    int32 stock_quantity = 5;
+    string category = 6;
+    string brand = 7;
+    repeated string tags = 8;
+    bool is_active = 9;
+    string sku = 10;
+}
+
+message Order {
+    string id = 1;
+    string customer_id = 2;
+    string product_id = 3;
+    int32 quantity = 4;
+    repeated string tags = 5;
+}
+
+message EnrichedOrder {
+    Order order = 1;
+    Product product = 2;
+} 

--- a/benches/src/mock_data.rs
+++ b/benches/src/mock_data.rs
@@ -1,0 +1,30 @@
+use crate::types::{Order, Product};
+use fake::Fake;
+use fake::faker::company::en::*;
+use fake::faker::lorem::en::*;
+use uuid::Uuid;
+
+pub fn mock_product(size: usize) -> Product {
+    Product {
+        id: Uuid::new_v4().to_string(),
+        name: Words(size..(size * 2)).fake::<Vec<String>>().join(" "),
+        description: Paragraph(size..(size * 2)).fake(),
+        price: (10.0..1000.0).fake(),
+        stock_quantity: (0..1000).fake(),
+        category: Words(1..2).fake::<Vec<String>>().join(" "),
+        brand: CompanyName().fake(),
+        tags: Words(size * 2..size * 3).fake::<Vec<String>>(),
+        is_active: true,
+        sku: Uuid::new_v4().to_string(),
+    }
+}
+
+pub fn mock_order(size: usize) -> Order {
+    Order {
+        id: Uuid::new_v4().to_string(),
+        customer_id: Uuid::new_v4().to_string(),
+        product_id: Uuid::new_v4().to_string(),
+        quantity: (1..100).fake(),
+        tags: Words(size..(size * 2)).fake::<Vec<String>>(),
+    }
+}

--- a/benches/src/serialization.rs
+++ b/benches/src/serialization.rs
@@ -60,7 +60,7 @@ fn benchmark_deserialize(c: &mut Criterion) {
 
 fn benchmark_merge(c: &mut Criterion) {
     let mut group = c.benchmark_group("merge");
-    
+
     // Test different sizes
     for size in [1, 5, 10].iter() {
         let product = mock_data::mock_product(*size);
@@ -103,7 +103,7 @@ fn benchmark_merge(c: &mut Criterion) {
             })
         });
     }
-    
+
     group.finish();
 }
 

--- a/benches/src/serialization.rs
+++ b/benches/src/serialization.rs
@@ -1,0 +1,116 @@
+mod mock_data;
+mod types;
+
+use bytes::BytesMut;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use imprint::{ImprintRecord, Merge, Read, Write};
+use prost::Message;
+use types::{EnrichedOrder, Order, Product};
+
+fn benchmark_serialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serialize");
+    let product = mock_data::mock_product(5);
+
+    // Baseline (Protobuf Serde)
+    group.bench_function("protobuf_serialize", |b| {
+        b.iter(|| {
+            let mut buf = Vec::new();
+            product.encode(&mut buf).unwrap();
+            black_box(buf);
+        })
+    });
+
+    let imprint_product = product.to_imprint();
+    group.bench_function("imprint_serialize", |b| {
+        b.iter(|| {
+            let mut buf = BytesMut::new();
+            imprint_product.write(&mut buf).unwrap();
+            black_box(buf);
+        })
+    });
+
+    group.finish();
+}
+
+fn benchmark_deserialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deserialize");
+    let product = mock_data::mock_product(5);
+    let mut buf = Vec::new();
+    product.encode(&mut buf).unwrap();
+
+    group.bench_function("protobuf_deserialize", |b| {
+        b.iter(|| {
+            let product = Product::decode(&buf[..]).unwrap();
+            black_box(product);
+        })
+    });
+
+    let imprint_product = product.to_imprint();
+    let mut buf = BytesMut::new();
+    imprint_product.write(&mut buf).unwrap();
+
+    group.bench_function("imprint_deserialize", |b| {
+        b.iter(|| {
+            let product = ImprintRecord::read(buf.clone().freeze()).unwrap();
+            black_box(product);
+        })
+    });
+    group.finish();
+}
+
+fn benchmark_merge(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merge");
+    
+    // Test different sizes
+    for size in [1, 5, 10].iter() {
+        let product = mock_data::mock_product(*size);
+        let order = mock_data::mock_order(*size);
+
+        let product_buf = product.encode_to_vec();
+        let order_buf = order.encode_to_vec();
+
+        group.bench_function(format!("protobuf_merge_size_{}", size), |b| {
+            b.iter(|| {
+                let product = Product::decode(&product_buf[..]).unwrap();
+                let order = Order::decode(&order_buf[..]).unwrap();
+
+                let enriched = EnrichedOrder {
+                    order: Some(order.clone()),
+                    product: Some(product.clone()),
+                };
+
+                black_box(enriched.encode_to_vec());
+            })
+        });
+
+        let product_imprint = product.to_imprint();
+        let order_imprint = order.to_imprint();
+
+        let mut product_buf = BytesMut::new();
+        product_imprint.write(&mut product_buf).unwrap();
+        let mut order_buf = BytesMut::new();
+        order_imprint.write(&mut order_buf).unwrap();
+
+        group.bench_function(format!("imprint_merge_size_{}", size), |b| {
+            b.iter(|| {
+                let (product, _) = ImprintRecord::read(product_buf.clone().freeze()).unwrap();
+                let (order, _) = ImprintRecord::read(order_buf.clone().freeze()).unwrap();
+
+                let enriched = product.merge(&order).unwrap();
+                let mut buf = BytesMut::new();
+                enriched.write(&mut buf).unwrap();
+                black_box(buf);
+            })
+        });
+    }
+    
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_serialize,
+    benchmark_deserialize,
+    benchmark_merge
+);
+criterion_main!(benches);

--- a/benches/src/types.rs
+++ b/benches/src/types.rs
@@ -1,0 +1,72 @@
+use imprint::{ImprintRecord, ImprintWriter, SchemaId, Value};
+
+include!(concat!(env!("OUT_DIR"), "/test.rs"));
+
+impl Product {
+    pub fn to_imprint(&self) -> ImprintRecord {
+        let mut writer = ImprintWriter::new(SchemaId {
+            fieldspace_id: 0,
+            schema_hash: 0,
+        })
+        .unwrap();
+
+        writer.add_field(1, Value::String(self.id.clone())).unwrap();
+        writer
+            .add_field(2, Value::String(self.name.clone()))
+            .unwrap();
+        writer
+            .add_field(3, Value::String(self.description.clone()))
+            .unwrap();
+        writer.add_field(4, Value::Float64(self.price)).unwrap();
+        writer
+            .add_field(5, Value::Int32(self.stock_quantity))
+            .unwrap();
+        writer
+            .add_field(6, Value::String(self.category.clone()))
+            .unwrap();
+        writer
+            .add_field(7, Value::String(self.brand.clone()))
+            .unwrap();
+        writer
+            .add_field(
+                8,
+                Value::Array(self.tags.iter().map(|t| Value::String(t.clone())).collect()),
+            )
+            .unwrap();
+        writer.add_field(9, Value::Bool(self.is_active)).unwrap();
+        writer
+            .add_field(10, Value::String(self.sku.clone()))
+            .unwrap();
+
+        writer.build().unwrap()
+    }
+}
+
+impl Order {
+    pub fn to_imprint(&self) -> ImprintRecord {
+        let mut writer = ImprintWriter::new(SchemaId {
+            fieldspace_id: 0,
+            schema_hash: 1,
+        })
+        .unwrap();
+
+        writer
+            .add_field(101, Value::String(self.id.clone()))
+            .unwrap();
+        writer
+            .add_field(102, Value::String(self.customer_id.clone()))
+            .unwrap();
+        writer
+            .add_field(103, Value::String(self.product_id.clone()))
+            .unwrap();
+        writer.add_field(104, Value::Int32(self.quantity)).unwrap();
+        writer
+            .add_field(
+                105,
+                Value::Array(self.tags.iter().map(|t| Value::String(t.clone())).collect()),
+            )
+            .unwrap();
+
+        writer.build().unwrap()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod varint;
 mod writer;
 
 pub use error::ImprintError;
-pub use ops::{Merge, Project};
+pub use ops::{Merge, MergeOptions, Project};
 pub use serde::{Read, Write};
 pub use types::{
     DirectoryEntry, Flags, Header, ImprintRecord, MAGIC, SchemaId, TypeCode, VERSION, Value,


### PR DESCRIPTION
Relates to #4 

This PR adds some basic benchmarks comparing the performance between protobuf and imprint for serde and merge operations. You can run these benchmarks with `cargo bench -p imprint-benchmarks`.

There are three categories of benchmarks:
1. there's serialization, which simply serializes a basic record into bytes
2. there's deserialization, which simply grabs the bytes and loads it into memory
3. there's the "merge" benchmark, which deserializes two records, merges them into a combined record, and reserializes the output. This one parameterizes on the size of the record to show that as the data size increases imprint pulls ahead.

Here are the initial results, which I'll publish to the `README.md` after merging this:

| Benchmark       | Protobuf (ns) | Imprint (ns) | % Improvement (Imprint faster) |
|----------------|----------------|--------------|--------------------------------|
| serialize       | 355.53           | 224.99           | 36.72%                        |
| deserialize     | 769.29           | 248.19           | 67.74%                        |
| merge_size_1    | 1003.50          | 784.04           | 21.87%                        |
| merge_size_5    | 2140.10          | 798.71           | 62.68%                        |
| merge_size_10   | 3453.90          | 797.41           | 76.91%                        |

**NOTE**: it's important to recognize that these benchmarks are showcasing the "best case" use cases for Imprint because the benchmark is not accessing any fields so no deserialization of individual fields is necessary. We believe this use case is pretty common in data denormalization pipelines (or at least, many fields do not need to be accessed), so it is representative of real use scenarios.