### PR TITLE
Add primitive and complex values

### DIFF
--- a/benches/src/types.rs
+++ b/benches/src/types.rs
@@ -1,4 +1,4 @@
-use imprint::{ImprintRecord, ImprintWriter, SchemaId, Value};
+use imprint::{ImprintRecord, ImprintWriter, SchemaId};
 
 include!(concat!(env!("OUT_DIR"), "/test.rs"));
 
@@ -10,33 +10,27 @@ impl Product {
         })
         .unwrap();
 
-        writer.add_field(1, Value::String(self.id.clone())).unwrap();
+        writer.add_field(1, self.id.clone().into()).unwrap();
+        writer.add_field(2, self.name.clone().into()).unwrap();
         writer
-            .add_field(2, Value::String(self.name.clone()))
+            .add_field(3, self.description.clone().into())
             .unwrap();
-        writer
-            .add_field(3, Value::String(self.description.clone()))
-            .unwrap();
-        writer.add_field(4, Value::Float64(self.price)).unwrap();
-        writer
-            .add_field(5, Value::Int32(self.stock_quantity))
-            .unwrap();
-        writer
-            .add_field(6, Value::String(self.category.clone()))
-            .unwrap();
-        writer
-            .add_field(7, Value::String(self.brand.clone()))
-            .unwrap();
+        writer.add_field(4, self.price.into()).unwrap();
+        writer.add_field(5, self.stock_quantity.into()).unwrap();
+        writer.add_field(6, self.category.clone().into()).unwrap();
+        writer.add_field(7, self.brand.clone().into()).unwrap();
         writer
             .add_field(
                 8,
-                Value::Array(self.tags.iter().map(|t| Value::String(t.clone())).collect()),
+                self.tags
+                    .iter()
+                    .map(|t| t.clone())
+                    .collect::<Vec<_>>()
+                    .into(),
             )
             .unwrap();
-        writer.add_field(9, Value::Bool(self.is_active)).unwrap();
-        writer
-            .add_field(10, Value::String(self.sku.clone()))
-            .unwrap();
+        writer.add_field(9, self.is_active.into()).unwrap();
+        writer.add_field(10, self.sku.clone().into()).unwrap();
 
         writer.build().unwrap()
     }
@@ -50,20 +44,22 @@ impl Order {
         })
         .unwrap();
 
+        writer.add_field(101, self.id.clone().into()).unwrap();
         writer
-            .add_field(101, Value::String(self.id.clone()))
+            .add_field(102, self.customer_id.clone().into())
             .unwrap();
         writer
-            .add_field(102, Value::String(self.customer_id.clone()))
+            .add_field(103, self.product_id.clone().into())
             .unwrap();
-        writer
-            .add_field(103, Value::String(self.product_id.clone()))
-            .unwrap();
-        writer.add_field(104, Value::Int32(self.quantity)).unwrap();
+        writer.add_field(104, self.quantity.into()).unwrap();
         writer
             .add_field(
                 105,
-                Value::Array(self.tags.iter().map(|t| Value::String(t.clone())).collect()),
+                self.tags
+                    .iter()
+                    .map(|t| t.clone())
+                    .collect::<Vec<_>>()
+                    .into(),
             )
             .unwrap();
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -189,7 +189,7 @@ impl Merge for ImprintRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ImprintWriter, Value};
+    use crate::ImprintWriter;
 
     fn create_test_record() -> ImprintRecord {
         let mut writer = ImprintWriter::new(SchemaId {
@@ -198,12 +198,10 @@ mod tests {
         })
         .unwrap();
 
-        writer.add_field(1, Value::Int32(42)).unwrap();
-        writer
-            .add_field(3, Value::String("hello".to_string()))
-            .unwrap();
-        writer.add_field(5, Value::Bool(true)).unwrap();
-        writer.add_field(7, Value::Bytes(vec![1, 2, 3])).unwrap();
+        writer.add_field(1, 42.into()).unwrap();
+        writer.add_field(3, "hello".into()).unwrap();
+        writer.add_field(5, true.into()).unwrap();
+        writer.add_field(7, vec![1, 2, 3].into()).unwrap();
 
         writer.build().unwrap()
     }
@@ -218,8 +216,8 @@ mod tests {
 
         // Then only the requested fields should be present
         assert_eq!(projected.directory.len(), 2);
-        assert_eq!(projected.get_value(1).unwrap(), Some(Value::Int32(42)));
-        assert_eq!(projected.get_value(5).unwrap(), Some(Value::Bool(true)));
+        assert_eq!(projected.get_value(1).unwrap(), Some(42.into()));
+        assert_eq!(projected.get_value(5).unwrap(), Some(true.into()));
 
         // And non-requested fields should be absent
         assert_eq!(projected.get_value(3).unwrap(), None);
@@ -236,16 +234,10 @@ mod tests {
 
         // Then all requested fields should be present with correct values
         assert_eq!(projected.directory.len(), 4);
-        assert_eq!(projected.get_value(1).unwrap(), Some(Value::Int32(42)));
-        assert_eq!(
-            projected.get_value(3).unwrap(),
-            Some(Value::String("hello".to_string()))
-        );
-        assert_eq!(projected.get_value(5).unwrap(), Some(Value::Bool(true)));
-        assert_eq!(
-            projected.get_value(7).unwrap(),
-            Some(Value::Bytes(vec![1, 2, 3]))
-        );
+        assert_eq!(projected.get_value(1).unwrap(), Some(42.into()));
+        assert_eq!(projected.get_value(3).unwrap(), Some("hello".into()));
+        assert_eq!(projected.get_value(5).unwrap(), Some(true.into()));
+        assert_eq!(projected.get_value(7).unwrap(), Some(vec![1, 2, 3].into()));
 
         // And directory should maintain sorted order
         let dir_ids: Vec<u32> = projected.directory.iter().map(|e| e.id).collect();
@@ -265,10 +257,7 @@ mod tests {
 
         // Then only that field should be present
         assert_eq!(projected.directory.len(), 1);
-        assert_eq!(
-            projected.get_value(3).unwrap(),
-            Some(Value::String("hello".to_string()))
-        );
+        assert_eq!(projected.get_value(3).unwrap(), Some("hello".into()));
     }
 
     #[test]
@@ -315,7 +304,7 @@ mod tests {
 
         // Then only existing fields should be included
         assert_eq!(projected.directory.len(), 1);
-        assert_eq!(projected.get_value(1).unwrap(), Some(Value::Int32(42)));
+        assert_eq!(projected.get_value(1).unwrap(), Some(42.into()));
         assert_eq!(projected.get_value(99).unwrap(), None);
         assert_eq!(projected.get_value(100).unwrap(), None);
     }
@@ -330,7 +319,7 @@ mod tests {
 
         // Then field should only appear once
         assert_eq!(projected.directory.len(), 1);
-        assert_eq!(projected.get_value(1).unwrap(), Some(Value::Int32(42)));
+        assert_eq!(projected.get_value(1).unwrap(), Some(42.into()));
     }
 
     #[test]
@@ -378,12 +367,10 @@ mod tests {
         .unwrap();
 
         // Add a mix of small and large fields
-        writer.add_field(1, Value::Int32(42)).unwrap(); // 4 bytes
-        writer
-            .add_field(2, Value::String("a".repeat(1000)))
-            .unwrap(); // ~1000 bytes
-        writer.add_field(3, Value::Int64(123)).unwrap(); // 8 bytes
-        writer.add_field(4, Value::Bytes(vec![0; 500])).unwrap(); // 500 bytes
+        writer.add_field(1, 42.into()).unwrap(); // 4 bytes
+        writer.add_field(2, "a".repeat(1000).into()).unwrap(); // ~1000 bytes
+        writer.add_field(3, 123i64.into()).unwrap(); // 8 bytes
+        writer.add_field(4, vec![0; 500].into()).unwrap(); // 500 bytes
         let record = writer.build().unwrap();
 
         let original_payload_size = record.payload.len();
@@ -409,8 +396,8 @@ mod tests {
         );
 
         // And the values should still be correct
-        assert_eq!(projected.get_value(1).unwrap(), Some(Value::Int32(42)));
-        assert_eq!(projected.get_value(3).unwrap(), Some(Value::Int64(123)));
+        assert_eq!(projected.get_value(1).unwrap(), Some(42.into()));
+        assert_eq!(projected.get_value(3).unwrap(), Some(123i64.into()));
     }
 
     #[test]
@@ -421,10 +408,8 @@ mod tests {
             schema_hash: 0xdeadbeef,
         })
         .unwrap();
-        writer1.add_field(1, Value::Int32(42)).unwrap();
-        writer1
-            .add_field(3, Value::String("hello".to_string()))
-            .unwrap();
+        writer1.add_field(1, 42.into()).unwrap();
+        writer1.add_field(3, "hello".into()).unwrap();
         let record1 = writer1.build().unwrap();
 
         let mut writer2 = ImprintWriter::new(SchemaId {
@@ -432,8 +417,8 @@ mod tests {
             schema_hash: 0xcafebabe,
         })
         .unwrap();
-        writer2.add_field(2, Value::Bool(true)).unwrap();
-        writer2.add_field(4, Value::Int64(123)).unwrap();
+        writer2.add_field(2, true.into()).unwrap();
+        writer2.add_field(4, 123.into()).unwrap();
         let record2 = writer2.build().unwrap();
 
         // When merging the records
@@ -441,13 +426,10 @@ mod tests {
 
         // Then all fields should be present
         assert_eq!(merged.directory.len(), 4);
-        assert_eq!(merged.get_value(1).unwrap(), Some(Value::Int32(42)));
-        assert_eq!(merged.get_value(2).unwrap(), Some(Value::Bool(true)));
-        assert_eq!(
-            merged.get_value(3).unwrap(),
-            Some(Value::String("hello".to_string()))
-        );
-        assert_eq!(merged.get_value(4).unwrap(), Some(Value::Int64(123)));
+        assert_eq!(merged.get_value(1).unwrap(), Some(42.into()));
+        assert_eq!(merged.get_value(2).unwrap(), Some(true.into()));
+        assert_eq!(merged.get_value(3).unwrap(), Some("hello".into()));
+        assert_eq!(merged.get_value(4).unwrap(), Some(123.into()));
     }
 
     #[test]
@@ -458,10 +440,8 @@ mod tests {
             schema_hash: 0xdeadbeef,
         })
         .unwrap();
-        writer1.add_field(1, Value::Int32(42)).unwrap();
-        writer1
-            .add_field(2, Value::String("first".to_string()))
-            .unwrap();
+        writer1.add_field(1, 42.into()).unwrap();
+        writer1.add_field(2, "first".into()).unwrap();
         let record1 = writer1.build().unwrap();
 
         let mut writer2 = ImprintWriter::new(SchemaId {
@@ -469,10 +449,8 @@ mod tests {
             schema_hash: 0xcafebabe,
         })
         .unwrap();
-        writer2
-            .add_field(2, Value::String("second".to_string()))
-            .unwrap();
-        writer2.add_field(3, Value::Bool(true)).unwrap();
+        writer2.add_field(2, "second".into()).unwrap();
+        writer2.add_field(3, true.into()).unwrap();
         let record2 = writer2.build().unwrap();
 
         // When merging with default options (keep zombie data)
@@ -480,12 +458,9 @@ mod tests {
 
         // Then first occurrence of duplicate fields should be kept
         assert_eq!(merged.directory.len(), 3);
-        assert_eq!(merged.get_value(1).unwrap(), Some(Value::Int32(42)));
-        assert_eq!(
-            merged.get_value(2).unwrap(),
-            Some(Value::String("first".to_string()))
-        );
-        assert_eq!(merged.get_value(3).unwrap(), Some(Value::Bool(true)));
+        assert_eq!(merged.get_value(1).unwrap(), Some(42.into()));
+        assert_eq!(merged.get_value(2).unwrap(), Some("first".into()));
+        assert_eq!(merged.get_value(3).unwrap(), Some(true.into()));
 
         // And payload should be larger due to zombie data
         let filtered_merged = record1
@@ -507,7 +482,7 @@ mod tests {
             schema_hash: 0xdeadbeef,
         };
         let mut writer1 = ImprintWriter::new(schema1).unwrap();
-        writer1.add_field(1, Value::Int32(42)).unwrap();
+        writer1.add_field(1, 42.into()).unwrap();
         let record1 = writer1.build().unwrap();
 
         let schema2 = SchemaId {
@@ -515,7 +490,7 @@ mod tests {
             schema_hash: 0xcafebabe,
         };
         let mut writer2 = ImprintWriter::new(schema2).unwrap();
-        writer2.add_field(2, Value::Bool(true)).unwrap();
+        writer2.add_field(2, true.into()).unwrap();
         let record2 = writer2.build().unwrap();
 
         // When merging the records


### PR DESCRIPTION
This PR introduces complex and primitive values. This will be useful when we add Map types, since Maps typically only support primitive keys. We don't have a way to distinguish this right now. After this PR, we will.