### PR TITLE
Add `MapKey` and `into()`'s

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -108,6 +108,78 @@ impl Value {
     }
 }
 
+impl From<bool> for Value {
+    fn from(b: bool) -> Value {
+        Value::Bool(b)
+    }
+}
+
+impl From<i32> for Value {
+    fn from(i: i32) -> Value {
+        Value::Int32(i)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(i: i64) -> Value {
+        Value::Int64(i)
+    }
+}
+
+impl From<f32> for Value {
+    fn from(f: f32) -> Value {
+        Value::Float32(f)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(f: f64) -> Value {
+        Value::Float64(f)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(b: Vec<u8>) -> Value {
+        Value::Bytes(b)
+    }
+}
+
+impl From<Bytes> for Value {
+    fn from(b: Bytes) -> Value {
+        Value::Bytes(b.into())
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Value {
+        Value::String(s)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Value {
+        Value::String(s.to_string())
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    fn from(v: Vec<T>) -> Value {
+        Value::Array(v.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<Box<ImprintRecord>> for Value {
+    fn from(r: Box<ImprintRecord>) -> Value {
+        Value::Row(r)
+    }
+}
+
+impl From<ImprintRecord> for Value {
+    fn from(r: ImprintRecord) -> Value {
+        Value::Row(Box::new(r))
+    }
+}
+
 impl From<MapKey> for Value {
     fn from(key: MapKey) -> Value {
         match key {


### PR DESCRIPTION
After some discussion in #17, I've abandoned using Rust's type system as a way to type composition in imprint. Instead, per-@agavra's suggestion, this PR adds `MapKey`. This is meant to lay the groundwork for a `TypeCode::Map` and `Value::Map(HashMap<MapKey, Value>)`. The idea here is to restrict the types that are allows for map keys since Avro only allows strings and protobufs only i32, i64, and String. I chose to also allow `Bytes` since it seemed silly to do strings but not bytes. If there's an objection, I can remove that, though. Perhaps it's wise to keep the types very narrow.

I also included the `.into()` functions for `Value` and `MapKey`, mostly just because they're very handy. I can split them into a separate PR if need be.